### PR TITLE
Update reference: openshift.org -> okd.io

### DIFF
--- a/docs/ext_docs.md
+++ b/docs/ext_docs.md
@@ -9,7 +9,7 @@ symbol in the top bar of the web interface and selecting "About" or with the `oc
 command line command while logged in to the OpenShift environment.
 
   * [Kubernetes documentation](https://kubernetes.io/docs/home/)
-  * [OpenShift documentation](https://docs.openshift.org/)
+  * [OpenShift documentation](https://docs.okd.io/)
 
 You could also have a look at "Awesome Kubernetes" which is a curated list of
 links about Kubernetes:

--- a/docs/introduction/background.md
+++ b/docs/introduction/background.md
@@ -117,7 +117,7 @@ of the most important abstractions, but we highly recommend that you read the
 concept documentation for Kubernetes and OpenShift as well:
 
    * [Kubernetes concepts](https://kubernetes.io/docs/concepts/)
-   * [OpenShift concepts](https://docs.openshift.org/latest/architecture/core_concepts/index.html)
+   * [OpenShift concepts](https://docs.okd.io/latest/architecture/core_concepts/index.html)
 
 Most of the abstractions are common to both plain Kubernetes and OpenShift, but
 OpenShift also introduces some of its own concepts.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -64,4 +64,4 @@ oc replace -f somefile.yaml
 See the official documentation for more information on using the command line
 interface:
 
-   * [OpenShift documentation: CLI reference](https://docs.openshift.org/latest/cli_reference/index.html)
+   * [OpenShift documentation: CLI reference](https://docs.okd.io/latest/cli_reference/index.html)

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -35,6 +35,6 @@ and you will see the application catalog where you can pick from various
 application templates or import your own.
 
 For more information about using the web user interface, you can refer to the
-[official OpenShift documentation](https://docs.openshift.org/). You can find
+[official OpenShift documentation](https://docs.okd.io/). You can find
 out which version of the documentation to look at in the web interface by
 clicking the question mark symbol in the top bar and selecting "About".


### PR DESCRIPTION
Since OpenShift Origin has been renamed to OKD and the URL of its site
has changed, update our links accordingly.