### PR TITLE
Update usage of OPENSHIFT_VERSION

### DIFF
--- a/docs/introduction/technical_maturity.md
+++ b/docs/introduction/technical_maturity.md
@@ -10,7 +10,7 @@ kinds of workloads it is suitable for at the moment.
 
 | Maturity indicator          | Current value                                       | Best feasible value                                              |
 |-----------------------------|-----------------------------------------------------|------------------------------------------------------------------|
-| **OpenShift version**       | {: class='td_ok'}\env{OPENSHIFT_VERSION}            | 3.9{: class='td_ok'}                                             |
+| **OpenShift version**       | {: class='td_ok'}\env{OPENSHIFT_VERSION}            | 3.11{: class='td_ok'}                                             |
 | **Service level**           | Best effort (no formal SLA){: class='td_warn'}      | JHS174 level B (99%, service times 7-19){: class='td_ok'}        |
 | **GlusterFS storage class** | Technical preview{: class='td_warn'}                | Technical preview{: class='td_warn'}                             |
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -10,23 +10,13 @@ The information for downloading the oc tool and logging in from the command line
 can be found in the "Command Line Tools" page in the web interface. After
 logging in to the web interface, you can find the page here:
 
-\if{OPENSHIFT_VERSION == 3.6}
-![Command line tools](img/cli_help_menu.png)
-\endif
-\if{OPENSHIFT_VERSION == 3.7}
 ![Command line tools](img/cli_help_menu_3.7.png)
-\endif
 
 The oc tool is a single binary that just needs to be placed in your path. You
 can find the oc command to login in one the fields on the page. There is a
 button next to it to copy the command to the clipboard:
 
-\if{OPENSHIFT_VERSION == 3.6}
-![OpenShift Command Line Tools page](img/openshift_cli_dialog.png)
-\endif
-\if{OPENSHIFT_VERSION == 3.7}
 ![OpenShift Command Line Tools page](img/openshift_cli_dialog_3.7.png)
-\endif
 
 Copy the command and paste it into a terminal to start using OpenShift via the
 command line.

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -11,22 +11,12 @@
 You can login at \env{OSO_WEB_UI_URL} (see [Getting access](../introduction/access)
 for instructions). After logging in, you should see a page like this:
 
-\if{OPENSHIFT_VERSION == 3.6}
-![OpenShift main page](img/openshift_main_page.png)
-\endif
-\if{OPENSHIFT_VERSION == 3.7}
 ![OpenShift main page](img/openshift_main_page_3.7.png)
-\endif
 
 Click the blue "Create Project" button to create a project and you will be
 presented with this view:
 
-\if{OPENSHIFT_VERSION == 3.6}
-![OpenShift new project dialog](img/new_project_dialog.png)
-\endif
-\if{OPENSHIFT_VERSION == 3.7}
 ![OpenShift new project dialog](img/new_project_dialog_3.7.png)
-\endif
 
 Here you'll need to pick a unique name that is not in use by any other project
 in the system. You can also enter a human readable display name and a


### PR DESCRIPTION
Only use OPENSHIFT_VERSION in the technical maturity table and not in
conditionals. This should prevent images from breaking. This also means
that we no longer use different images between different OpenShift
versions. The support can be reintroduced if needed later on.