### PR TITLE
Fix Nginx configuration for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,7 @@ ENV ROOT_GROUP_DIRS='/var/run /var/log/nginx /var/lib/nginx'
 RUN yum -y install epel-release &&\
     yum -y install nginx python-pip python &&\
     yum clean all &&\
-    chmod g+rwx /var/run /var/log/nginx &&\
-    sed -i -e "/listen\(.*\)\[/d" \
-           -e "s/listen\(.*\)80 default_server;/listen 8000 default_server;/" \
-           -e "s/^error_log \/var\/log\/nginx\/error.log;/error_log stderr;/" \
-           -e "/worker_processes/a daemon off;" \
-           -e "s/^user/#user/" /etc/nginx/nginx.conf
+    chmod g+rwx /var/run /var/log/nginx
 
 RUN chgrp -R root ${ROOT_GROUP_DIRS} &&\
     chmod -R g+rwx ${ROOT_GROUP_DIRS}
@@ -41,6 +36,8 @@ WORKDIR /tmp
 RUN pip install --no-cache-dir -r requirements.txt && \
     sh -c /tmp/make_config.sh && \
     mkdocs build -d /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx
 
 EXPOSE 8000
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,19 +3,19 @@ familiar with container technology or container orchestration systems such as
 Kubernetes or OpenShift, you could start by reading a generic introduction to
 the topic:
 
-  * [Background on container orchestration](introduction/background)
+  * [Background on container orchestration](/introduction/background/)
 
 If you are already familiar with container technology and Kubernetes/OpenShift,
 you could move directly to the instructions for getting access to \env{SYSTEM_NAME}:
 
-  * [Getting access](introduction/access)
+  * [Getting access](/introduction/access/)
 
 If you already have access to \env{SYSTEM_NAME}, then you can skip ahead to usage
 documentation and the links to external documentation:
 
-  * [Usage](usage/getting_started)
-  * [External documentation](ext_docs)
+  * [Usage](/usage/getting_started/)
+  * [External documentation](/ext_docs/)
 
 Want to get in touch? See the contact page:
 
-  * [Contact](contact)
+  * [Contact](/contact/)

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,91 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+#user nginx;
+worker_processes auto;
+daemon off;
+error_log stderr;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen 8000 default_server;
+        try_files $uri $uri/ =404;
+        server_name  _;
+        server_name_in_redirect off;
+        port_in_redirect off;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2 default_server;
+#        server_name  _;
+#        root         /usr/share/nginx/html;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers HIGH:!aNULL:!MD5;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        location / {
+#        }
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}


### PR DESCRIPTION
Fix Nginx configuration so that it redirects links like "access" to
"access/". At the same time create a separate file for the config that
is copied into the Docker container image instead of using sed to modify
the config file. This makes it much easier to make changes to Nginx
config in the future.

NB: This breaks the current Dockerfile for running locally on one's
laptop, but it's more important that this works in OpenShift. We can fix
the local case next, but the priority should be to fix what's running in
OpenShift.