### PR TITLE
Make Nginx redirects relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo docker build -t rahti-user-guide \
 Then run the container:
 
 ```bash
-sudo docker run --rm -it -p 8000:8000 --name rahti-user-guide rahti-user-guide
+sudo docker run --rm -it -p 80:8000 --name rahti-user-guide rahti-user-guide
 ```
 
 ## Hosting on OpenShift

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,6 +40,7 @@ http {
         listen 8000 default_server;
         try_files $uri $uri/ =404;
         server_name  _;
+        absolute_redirect off;
         server_name_in_redirect off;
         port_in_redirect off;
         root         /usr/share/nginx/html;


### PR DESCRIPTION
Instead of using absolute redirects that also include the scheme, use
relative redirects instead. This way Nginx won't try to redirect the
user to the http scheme from https when running in OpenShift and issuing
301s.

Update the documentation for running Nginx locally to use port 80
instead of 8000 so that these new relative redirects also work when
testing Docker changes locally. The downside is that port 80 must be
available locally, but this is generally the case and if a user runs
Docker locally they should also have root locally to be able to bind to
port 80.