### PR TITLE
Clarify docs about CSC/OpenShift projects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,11 @@
+\if{LDAP_LOGIN_SUPPORT}
+!!! note
+    If you have access to \env{SYSTEM_NAME} via multiple CSC computing
+    projects, you may need to explicitly specify which one to use when
+    creating OpenShift projects. For more information, see the [projects and
+    quota documentation page](/usage/projects_and_quota).
+\endif
+
 Welcome to the \env{SYSTEM_NAME} container cloud! If you are not yet
 familiar with container technology or container orchestration systems such as
 Kubernetes or OpenShift, you could start by reading a generic introduction to

--- a/docs/usage/projects_and_quota.md
+++ b/docs/usage/projects_and_quota.md
@@ -45,12 +45,14 @@ from the billing unit quota of project_1000123. Note that project_1000123 must
 have \env{SYSTEM_NAME} access and you must be a member of that computing project
 or the OpenShift project creation will fail.
 
-You can also set a default billing project with the [My Projects
+If you would like to know which CSC computing projects you are a member of, you
+can view a list in the [My Projects
 tool](https://sui.csc.fi/group/sui/my-projects) of the Scientist's User
-Interface. Select the project that you would like to have as your default
-billing project and click "Set As Billing Project". After doing this, the
-default billing project will be selected as the billing project for OpenShift
-projects that don't explicitly specify one.
+Interface. You can also set a default billing project with the same tool. Select
+the project that you would like to have as your default billing project and
+click "Set As Billing Project". After doing this, the default billing project
+will be selected as the billing project for OpenShift projects that don't
+explicitly specify one.
 
 If you would like to know which CSC computing project an OpenShift project is
 associated with, you can do so using the oc command line tool. You can find


### PR DESCRIPTION
Add a note on the front page that mentions that Rahti users must now
pick a CSC computing project for their OpenShift projects if they have
several.

In the projects and quota documentation, mention that a list of a user's
CSC computing projects is available in SUI.