### PR TITLE
WIP: Docs migrate

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -2,4 +2,4 @@
 
 The main support address for container clouds at CSC:
 
-[rahti-support@csc.fi](mailto:rahti-support@csc.fi)
+[servicedesk@csc.fi](mailto:servicedesk@csc.fi)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,8 @@
 \endif
 
 !!! note
-    Need an account? Have a look at "<a href="./introduction/access">Getting access</a>".
+
+    Need an account? Have a look at [Getting access](\env{DOCS_PREFIX}/introduction/access/).
     If you already have an account, you can access \env{SYSTEM_NAME} via the buttons above.
 
 <!-- Welcome to the \env{SYSTEM_NAME} container cloud!  -->
@@ -16,7 +17,7 @@
 <!-- orchestration systems such as Kubernetes or OpenShift, you could start by -->
 <!-- reading a generic introduction to the topic: -->
 <!--  -->
-<!--   * [Background on container orchestration](\env{DOCS_PREFIX}/introduction/background/) -->
+  <!-- * [Background on container orchestration](\env{DOCS_PREFIX}/introduction/background/) -->
 <!--  -->
 <!-- If you are already familiar with container technology and Kubernetes/OpenShift, -->
 <!-- you could move directly to the instructions for getting access to \env{SYSTEM_NAME}: -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,24 +6,29 @@
     quota documentation page](/usage/projects_and_quota).
 \endif
 
-Welcome to the \env{SYSTEM_NAME} container cloud! If you are not yet
-familiar with container technology or container orchestration systems such as
-Kubernetes or OpenShift, you could start by reading a generic introduction to
-the topic:
+!!! note
+    Need an account? Have a look at "<a href="./introduction/access">Getting access</a>".
+    If you already have an account, you can access \env{SYSTEM_NAME} via the buttons above.
 
-  * [Background on container orchestration](/introduction/background/)
-
-If you are already familiar with container technology and Kubernetes/OpenShift,
-you could move directly to the instructions for getting access to \env{SYSTEM_NAME}:
-
-  * [Getting access](/introduction/access/)
-
-If you already have access to \env{SYSTEM_NAME}, then you can skip ahead to usage
-documentation and the links to external documentation:
-
-  * [Usage](/usage/getting_started/)
-  * [External documentation](/ext_docs/)
-
-Want to get in touch? See the contact page:
-
-  * [Contact](/contact/)
+<!-- Welcome to the \env{SYSTEM_NAME} container cloud!  -->
+<!--  -->
+<!-- If you are not yet familiar with container technology or container -->
+<!-- orchestration systems such as Kubernetes or OpenShift, you could start by -->
+<!-- reading a generic introduction to the topic: -->
+<!--  -->
+<!--   * [Background on container orchestration](\env{DOCS_PREFIX}/introduction/background/) -->
+<!--  -->
+<!-- If you are already familiar with container technology and Kubernetes/OpenShift, -->
+<!-- you could move directly to the instructions for getting access to \env{SYSTEM_NAME}: -->
+<!--  -->
+<!--   * [Getting access](\env{DOCS_PREFIX}/introduction/access/) -->
+<!--  -->
+<!-- If you already have access to \env{SYSTEM_NAME}, then you can skip ahead to usage -->
+<!-- documentation and the links to external documentation: -->
+<!--  -->
+<!--   * [Usage](\env{DOCS_PREFIX}/usage/getting_started/) -->
+<!--   * [External documentation](\env{DOCS_PREFIX}/ext_docs/) -->
+<!--  -->
+<!-- Want to get in touch? See the contact page: -->
+<!--  -->
+<!--   * [Contact](/contact/) -->

--- a/mkdocs.yml.j2
+++ b/mkdocs.yml.j2
@@ -6,7 +6,7 @@ pages:
     # - Service description: introduction/service_description.md
     # {% endif %}
     # - Background: introduction/background.md
-  - Technical maturity: introduction/technical_maturity.md
+  # - Technical maturity: introduction/technical_maturity.md
     # - Getting access: introduction/access.md
     {% if ('BILLING_ENABLED' | env) == 'True' %}
   - Billing: introduction/billing.md

--- a/mkdocs.yml.j2
+++ b/mkdocs.yml.j2
@@ -1,29 +1,29 @@
 site_name: {{ 'SYSTEM_NAME' | env }} container cloud
 pages:
   - Home: index.md
-  - Introduction:
-    {% if ('SHOW_AGREEMENTS' | env) != 'True' %}
-    - Service description: introduction/service_description.md
-    {% endif %}
-    - Background: introduction/background.md
-    - Technical maturity: introduction/technical_maturity.md
-    - Getting access: introduction/access.md
+  # - Introduction:
+    # {% if ('SHOW_AGREEMENTS' | env) != 'True' %}
+    # - Service description: introduction/service_description.md
+    # {% endif %}
+    # - Background: introduction/background.md
+  - Technical maturity: introduction/technical_maturity.md
+    # - Getting access: introduction/access.md
     {% if ('BILLING_ENABLED' | env) == 'True' %}
-    - Billing: introduction/billing.md
+  - Billing: introduction/billing.md
     {% endif %}
-  - Usage:
-    - Getting started: usage/getting_started.md
-    - Projects and quota: usage/projects_and_quota.md
-    - Command line tool usage: usage/cli.md
-    - Security guide: usage/security-guide.md
-  - Tutorials:
-    - Deploying applications from web console: tutorials/basic-console.md
-    - Core objects: tutorials/elemental_tutorial.md
-    - Utility objects: tutorials/advanced_tutorial.md
-    - Design patterns: tutorials/patterns.md
-  - Template documentation: template-docs.md
+  # - Usage:
+  #   - Getting started: usage/getting_started.md
+  #   - Projects and quota: usage/projects_and_quota.md
+  #   - Command line tool usage: usage/cli.md
+  #   - Security guide: usage/security-guide.md
+  # - Tutorials:
+  #   - Deploying applications from web console: tutorials/basic-console.md
+  #   - Core objects: tutorials/elemental_tutorial.md
+  #   - Utility objects: tutorials/advanced_tutorial.md
+  #   - Design patterns: tutorials/patterns.md
+  # - Template documentation: template-docs.md
   - Contact: contact.md
-  - External documentation: ext_docs.md
+  # - External documentation: ext_docs.md
   {% if ('SHOW_AGREEMENTS' | env) == 'True' %}
   - Agreements:
     - Terms of Use: agreements/terms_of_use.md
@@ -45,3 +45,4 @@ extra:
   system_name: {{ 'SYSTEM_NAME' | env }}
   oso_web_ui_url: {{ 'OSO_WEB_UI_URL' | env }}
   oso_registry_url: {{ 'OSO_REGISTRY_URL' | env }}
+  docs_prefix: {{ 'DOCS_PREFIX' | env }}

--- a/set_env_rahti.sh
+++ b/set_env_rahti.sh
@@ -2,10 +2,11 @@
 
 export BILLING_ENABLED=False
 export GITLAB_LOGIN_SUPPORT=False
-export LDAP_LOGIN_SUPPORT=True
+export LDAP_LOGIN_SUPPORT=False
 export OPENSHIFT_VERSION=3.11
 export OSO_REGISTRY_URL=https://registry-console.rahti.csc.fi
 export OSO_WEB_UI_URL=https://rahti.csc.fi:8443
-export SUI_INTEGRATION_DONE=False
+export SUI_INTEGRATION_DONE=True
 export SYSTEM_NAME=Rahti
 export SHOW_AGREEMENTS=True
+export DOCS_PREFIX=http://localhost:8001/#cloud/rahti

--- a/set_env_rahti.sh
+++ b/set_env_rahti.sh
@@ -9,4 +9,4 @@ export OSO_WEB_UI_URL=https://rahti.csc.fi:8443
 export SUI_INTEGRATION_DONE=True
 export SYSTEM_NAME=Rahti
 export SHOW_AGREEMENTS=True
-export DOCS_PREFIX=http://localhost:8001/#cloud/rahti
+export DOCS_PREFIX=https://csc-guide-preview.rahtiapp.fi/origin/rahti-migrate/#cloud/rahti

--- a/theme_customization/system_links.html
+++ b/theme_customization/system_links.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="platform_link_box">
-  <a href="{{ config.extra.docs_prefix }}" class="platform_link">
+  <a href="{{ config.extra.docs_prefix }}/" class="platform_link">
     {{ config.extra.system_name }} usage documentation
     <i class="fa fa-external-link platform_link_icon" aria-hidden="true"></i>
   </a>

--- a/theme_customization/system_links.html
+++ b/theme_customization/system_links.html
@@ -14,12 +14,9 @@
   </a>
 </div>
 
-<div class="admonition note">
-  <p class="admonition-title">
-    Note
-  </p>
-  <p>
-    Need an account? Have a look at "<a href="./introduction/access">Getting access</a>".
-    If you already have an account, you can access {{ config.extra.system_name }} via the buttons above.
-  </p>
+<div class="platform_link_box">
+  <a href="{{ config.extra.docs_prefix }}" class="platform_link">
+    {{ config.extra.system_name }} usage documentation
+    <i class="fa fa-external-link platform_link_icon" aria-hidden="true"></i>
+  </a>
 </div>


### PR DESCRIPTION
Commented out most of the documentation to be placed to https://rahti.csc.fi.

This is a sibling PR for https://github.com/CSCfi/csc-user-guide/pull/127. Preview of that is at https://csc-guide-preview.rahtiapp.fi/origin/rahti-migrate/#cloud/rahti/

Build configuration:
```bash
#!/bin/bash

export BILLING_ENABLED=False
export GITLAB_LOGIN_SUPPORT=False
export LDAP_LOGIN_SUPPORT=False
export OPENSHIFT_VERSION=3.11
export OSO_REGISTRY_URL=https://registry-console.rahti.csc.fi
export OSO_WEB_UI_URL=https://rahti.csc.fi:8443
export SUI_INTEGRATION_DONE=True
export SYSTEM_NAME=Rahti
export SHOW_AGREEMENTS=True
export DOCS_PREFIX=https://csc-guide-preview.rahtiapp.fi/origin/rahti-migrate/#cloud/rahti
```