### PR TITLE
Fix broken link redirection

### DIFF
--- a/mkdocs.yml.j2
+++ b/mkdocs.yml.j2
@@ -49,4 +49,4 @@ extra:
 plugins:
     - redirects:
         redirect_maps:
-            'introduction/billing.md': 'https://docs.csc.fi/cloud/rahti/introduction/billing/'
+            'introduction/billing.md': 'https://docs.csc.fi/cloud/rahti/billing/'


### PR DESCRIPTION
The billing page was moved in docs.csc.fi, this redirection was left behind.