### PR TITLE
fix broken rahti access link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 !!! note
 
-    Need an account? Have a look at [Getting access](\env{DOCS_PREFIX}/introduction/access/).
+    Need an account? Have a look at [Getting access](\env{DOCS_PREFIX}/access/).
     If you already have an account, you can access \env{SYSTEM_NAME} via the buttons above.
 
 <!-- Welcome to the \env{SYSTEM_NAME} container cloud!  -->


### PR DESCRIPTION
fixes a broken access link on the page https://rahti.csc.fi/